### PR TITLE
ZEEK-ONLY: avoid initialization of every calloc'd int in fd_map

### DIFF
--- a/src/linux/platform.c
+++ b/src/linux/platform.c
@@ -74,6 +74,18 @@ static void
 linux_kqueue_free(struct kqueue *kq);
 
 static void
+fd_map_set(int from, int to)
+{
+    fd_map[from] = to + 1;
+}
+
+static int
+fd_map_get(int fd)
+{
+    return fd_map[fd] - 1;
+}
+
+static void
 monitoring_thread_cleanup(UNUSED void *arg)
 {
     struct kqueue *kq, *kq_tmp;
@@ -178,7 +190,7 @@ monitoring_thread_kqueue_cleanup(int signal_fd)
      * Signal is received for read side of pipe
      * Get FD for write side as it's the kqueue identifier
      */
-    fd = fd_map[signal_fd];
+    fd = fd_map_get(signal_fd);
     if (fd < 0) {
        /* Should not happen */
         dbg_printf("fd=%i - not a known FD", fd);
@@ -235,8 +247,6 @@ monitoring_thread_loop(UNUSED void *arg)
     int res = 0;
     siginfo_t info;
 
-    int i;
-
     sigset_t monitoring_sig_set;
 
     /* Set the thread's name to something descriptive so it shows up in gdb,
@@ -263,8 +273,6 @@ monitoring_thread_loop(UNUSED void *arg)
     error:
         return NULL;
     }
-    for (i = 0; i < nb_max_fd; i++)
-        fd_map[i] = -1;
 
     fd_use_cnt = calloc(nb_max_fd, sizeof(unsigned int));
     if (fd_use_cnt == NULL){
@@ -298,7 +306,7 @@ monitoring_thread_loop(UNUSED void *arg)
          */
         pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
         tracing_mutex_lock(&kq_mtx);
-        dbg_printf("fd=%i - freeing kqueue due to fd closure (signal) for sfd=%i ", fd_map[info.si_fd], info.si_fd);
+        dbg_printf("fd=%i - freeing kqueue due to fd closure (signal) for sfd=%i ", fd_map_get(info.si_fd), info.si_fd);
 
         /*
          * Release resources used by this kqueue
@@ -535,7 +543,7 @@ linux_kqueue_init(struct kqueue *kq)
     }
 
     /* Update pipe FD map */
-    fd_map[kq->pipefd[0]] = kq->kq_id;
+    fd_map_set(kq->pipefd[0], kq->kq_id);
 
     /* Mark this id as in use */
     fd_use_cnt[kq->kq_id]++;


### PR DESCRIPTION
Same as #2, but with adjusted merge target as per Tim's request.